### PR TITLE
Initial inclusion of SBOM generation in GitHub actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -87,3 +87,21 @@ jobs:
 
       - name: Test
         run: dotnet test --no-restore --verbosity normal
+
+  sbom:
+    needs: [net6, net7, net8]
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Generate XML SBOM
+        uses: CycloneDX/gh-dotnet-generate-sbom@v1
+        with:
+          path: ./CycloneDX.sln
+          github-bearer-token: ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Generate JSON SBOM
+        uses: CycloneDX/gh-dotnet-generate-sbom@master
+        with:
+          path: ./CycloneDX.sln
+          json: true
+          github-bearer-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose of PR

To add SBOM generation during GitHub actions workflow runner.

We have taken a direct dependency on [gh-dotnet-generate-sbom](https://github.com/CycloneDX/gh-dotnet-generate-sbom) in order to generate the SBOM. The SBOM generation job requires all builds (.NET 6, 7, and 8) to complete before it will attempt to generate and SBOM.

## New Requirements

- [gh-dotnet-generate-sbom](https://github.com/CycloneDX/gh-dotnet-generate-sbom)